### PR TITLE
Add python version specifiers for `typing` and `enum34`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,8 @@ dependencies = [
     "pillow>=3.3.0",
     "pyusb",
     "attrs",
-    "typing",
-    "enum34",
+    "typing;python_version<\"3.5\"",
+    "enum34;python_version<\"3.4\"",
     "jsons",
 ]
 keywords = [


### PR DESCRIPTION
As `typing` is in stdlib starting from 3.5, and `enum34` is a backport from 3.4, these dependencies are not required from those versions onwards.

(While the absence of those packages on pypi for later versions is not a fatal error when installing using pip, it affects setuptools when used directly, which is typical for e.g., nixpkgs packaging of python modules.)